### PR TITLE
Modified FileOpenAction and FileSaveAsAction to use AWT.FileDialog on… Mac OS X

### DIFF
--- a/src/freedots/Main.java
+++ b/src/freedots/Main.java
@@ -60,6 +60,7 @@ public final class Main {
    * @param args Arguments from the command-line
    */
   public static void main(final String[] args) {
+    macSetup();
     Options options = null;
     try {
       options = new Options(args);
@@ -67,6 +68,7 @@ public final class Main {
       System.err.println("File not found: "+exception.getMessage());
       System.exit(1);
     }
+
     Transcriber transcriber = new Transcriber(options);
     if (options.getLocation() != null) {
       Score score = null;
@@ -146,6 +148,13 @@ public final class Main {
     }
   }
 
+   // Setup to use native features on OS X
+  private static void macSetup() {
+        if (System.getProperty("os.name").equals("Mac OS X")) {
+      System.setProperty("apple.laf.useScreenMenuBar", "true");
+      System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Freedots");
+    }
+   };
   // Constants from build.xml
   public static final String VERSION;
   static {

--- a/src/freedots/gui/swing/FileOpenAction.java
+++ b/src/freedots/gui/swing/FileOpenAction.java
@@ -24,15 +24,17 @@ package freedots.gui.swing;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Toolkit;
 import java.io.File;
-
+import java.io.FilenameFilter;
 import javax.swing.JFileChooser;
 import javax.swing.KeyStroke;
 import javax.swing.filechooser.FileFilter;
-
 import freedots.musicxml.Score;
 
-/**
+ /**
  * An action for selecting and loading MusicXML documents.
  */
 @SuppressWarnings("serial")
@@ -49,29 +51,18 @@ public final class FileOpenAction extends javax.swing.AbstractAction {
     putValue(SHORT_DESCRIPTION, "Open an existing MusicXML file");
     putValue(MNEMONIC_KEY, KeyEvent.VK_O);
     putValue(ACCELERATOR_KEY,
-             KeyStroke.getKeyStroke(KeyEvent.VK_O, ActionEvent.CTRL_MASK));
+             KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
   }
-  /** Launches a file open dialog and loads the selected file.
+/** Launches a file open dialog and loads the selected file.
    * @see java.awt.event.ActionListener#actionPerformed
    */
   public void actionPerformed(final ActionEvent event) {
-    JFileChooser fileChooser = new JFileChooser();
-    fileChooser.setAcceptAllFileFilterUsed(false);
-    fileChooser.setFileFilter(new FileFilter() {
-      @Override
-      public boolean accept(final File file) {
-        return file.isDirectory() || file.getName().matches(".*\\.(mxl|xml)");
-      }
-      @Override
-      public String getDescription() {
-        return "*.mxl, *.xml";
-      }
-    });
-    fileChooser.showOpenDialog(gui);
+    File file = selectFile();
+    String filename = file.getName();
     try {
       gui.setStatusMessage("Loading "
-                           + fileChooser.getSelectedFile().toString() + "...");
-      Score newScore = new Score(fileChooser.getSelectedFile().toString());
+                           + filename + "...");
+      Score newScore = new Score(file.getPath());
       gui.setStatusMessage("Transcribing to braille...");
       gui.setScore(newScore);
       gui.setStatusMessage("Ready");
@@ -79,7 +70,36 @@ public final class FileOpenAction extends javax.swing.AbstractAction {
     catch (javax.xml.parsers.ParserConfigurationException exception) {
       exception.printStackTrace();
     } catch (Exception exception) {
-      exception.printStackTrace();
+        exception.printStackTrace();
     }
+  }
+
+  public File selectFile() {
+    String osName = System.getProperty("os.name");
+    File file = null;
+    if (osName.equals("Mac OS X")) {
+      FileDialog fd = new FileDialog(new Frame(), "Choose a file", FileDialog.LOAD);
+      fd.setFile("*.xml");
+      fd.setVisible(true);
+      String fileName = fd.getDirectory() + "/" + fd.getFile();
+      file = new File(fileName);
+    }
+    else {
+      JFileChooser fileChooser = new JFileChooser();
+      fileChooser.setAcceptAllFileFilterUsed(false);
+      fileChooser.setFileFilter(new FileFilter() {
+        @Override
+        public boolean accept(final File file) {
+            return file.isDirectory() || file.getName().matches(".*\\.(mxl|xml)");
+        }
+        @Override
+        public String getDescription() {
+            return "*.mxl, *.xml";
+        }
+      });
+      fileChooser.showOpenDialog(gui);
+      file = fileChooser.getSelectedFile();
+    }
+    return file;
   }
 }

--- a/src/freedots/gui/swing/FileOpenAction.java
+++ b/src/freedots/gui/swing/FileOpenAction.java
@@ -24,15 +24,17 @@ package freedots.gui.swing;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Toolkit;
 import java.io.File;
-
+import java.io.FilenameFilter;
 import javax.swing.JFileChooser;
 import javax.swing.KeyStroke;
 import javax.swing.filechooser.FileFilter;
-
 import freedots.musicxml.Score;
 
-/**
+ /**
  * An action for selecting and loading MusicXML documents.
  */
 @SuppressWarnings("serial")
@@ -49,29 +51,18 @@ public final class FileOpenAction extends javax.swing.AbstractAction {
     putValue(SHORT_DESCRIPTION, "Open an existing MusicXML file");
     putValue(MNEMONIC_KEY, KeyEvent.VK_O);
     putValue(ACCELERATOR_KEY,
-             KeyStroke.getKeyStroke(KeyEvent.VK_O, ActionEvent.CTRL_MASK));
+             KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
   }
-  /** Launches a file open dialog and loads the selected file.
+/** Launches a file open dialog and loads the selected file.
    * @see java.awt.event.ActionListener#actionPerformed
    */
   public void actionPerformed(final ActionEvent event) {
-    JFileChooser fileChooser = new JFileChooser();
-    fileChooser.setAcceptAllFileFilterUsed(false);
-    fileChooser.setFileFilter(new FileFilter() {
-      @Override
-      public boolean accept(final File file) {
-        return file.isDirectory() || file.getName().matches(".*\\.(mxl|xml)");
-      }
-      @Override
-      public String getDescription() {
-        return "*.mxl, *.xml";
-      }
-    });
-    fileChooser.showOpenDialog(gui);
+    File file = selectFile();
+    String filename = file.getName();
     try {
       gui.setStatusMessage("Loading "
-                           + fileChooser.getSelectedFile().toString() + "...");
-      Score newScore = new Score(fileChooser.getSelectedFile().toString());
+                           + filename + "...");
+      Score newScore = new Score(filename);
       gui.setStatusMessage("Transcribing to braille...");
       gui.setScore(newScore);
       gui.setStatusMessage("Ready");
@@ -79,7 +70,36 @@ public final class FileOpenAction extends javax.swing.AbstractAction {
     catch (javax.xml.parsers.ParserConfigurationException exception) {
       exception.printStackTrace();
     } catch (Exception exception) {
-      exception.printStackTrace();
+        exception.printStackTrace();
     }
+  }
+
+  public File selectFile() {
+    String osName = System.getProperty("os.name");
+    File file = null;
+    if (osName.equals("Mac OS X")) {
+      FileDialog fd = new FileDialog(new Frame(), "Choose a file", FileDialog.LOAD);
+      fd.setFile("*.xml");
+      fd.setVisible(true);
+      String fileName = fd.getDirectory() + "/" + fd.getFile();
+      file = new File(fileName);
+    }
+    else {
+      JFileChooser fileChooser = new JFileChooser();
+      fileChooser.setAcceptAllFileFilterUsed(false);
+      fileChooser.setFileFilter(new FileFilter() {
+        @Override
+        public boolean accept(final File file) {
+            return file.isDirectory() || file.getName().matches(".*\\.(mxl|xml)");
+        }
+        @Override
+        public String getDescription() {
+            return "*.mxl, *.xml";
+        }
+      });
+      fileChooser.showOpenDialog(gui);
+      file = fileChooser.getSelectedFile();
+    }
+    return file;
   }
 }

--- a/src/freedots/gui/swing/FileOpenAction.java
+++ b/src/freedots/gui/swing/FileOpenAction.java
@@ -62,7 +62,7 @@ public final class FileOpenAction extends javax.swing.AbstractAction {
     try {
       gui.setStatusMessage("Loading "
                            + filename + "...");
-      Score newScore = new Score(filename);
+      Score newScore = new Score(file.getPath());
       gui.setStatusMessage("Transcribing to braille...");
       gui.setScore(newScore);
       gui.setStatusMessage("Ready");

--- a/src/freedots/gui/swing/FileSaveAsAction.java
+++ b/src/freedots/gui/swing/FileSaveAsAction.java
@@ -22,9 +22,14 @@
  */
 package freedots.gui.swing;
 
+import java.util.ArrayList;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Label;
 import java.io.File;
+import java.io.FilenameFilter;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -46,7 +51,6 @@ import freedots.transcription.Transcriber;
 @SuppressWarnings("serial")
 public final class FileSaveAsAction extends javax.swing.AbstractAction {
   private Main gui;
-
   /** Constructs a new action object for saving files.
    * @param gui is used to retrieve the currently loaded score object
    */
@@ -56,7 +60,7 @@ public final class FileSaveAsAction extends javax.swing.AbstractAction {
     putValue(SHORT_DESCRIPTION, "Export to braille or standard MIDI file");
     putValue(MNEMONIC_KEY, KeyEvent.VK_A);
   }
-  /** Uses [@link JFileChooser} to prompt the user for a file name to save to.
+  /** Prompts the user for a file name to save to.
    * <p>
    * The output file format is determined according to the file extension.
    * @see java.awt.event.ActionListener#actionPerformed
@@ -64,69 +68,81 @@ public final class FileSaveAsAction extends javax.swing.AbstractAction {
   public void actionPerformed(ActionEvent event) {
     Score score = gui.getScore();
     if (score != null) {
-      JFileChooser fileChooser = new JFileChooser();
-      fileChooser.setAcceptAllFileFilterUsed(false);
-      fileChooser.setFileFilter(new FileFilter() {
-        @Override
-        public boolean accept(File f) {
-          return f.isDirectory() || f.getName().matches(".*\\.brl");
-        }
-        @Override
-        public String getDescription() {
-          return "Unicode braille (*.brl)";
-        }
-      });
-      fileChooser.setFileFilter(new FileFilter() {
-        @Override
-        public boolean accept(File f) {
-          return f.isDirectory() || f.getName().matches(".*\\.brf");
-        }
-        @Override
-        public String getDescription() {
-          return "Legacy BRF (*.brf)";
-        }
-      });
-      fileChooser.setFileFilter(new FileFilter() {
-        @Override
-        public boolean accept(File f) {
-          return f.isDirectory() || f.getName().matches(".*\\.mid");
-        }
-        @Override
-        public String getDescription() {
-          return "Standard MIDI file (*.mid)";
-        }
-      });
-      fileChooser.setFileFilter(new FileFilter() {
-        @Override
-        public boolean accept(File f) {
-          return f.isDirectory() || f.getName().matches(".*\\.xml");
-        }
-        @Override
-        public String getDescription() {
-          return "MusicXML file (*.xml)";
-        }
-      });
-      if (fileChooser.showSaveDialog(gui) == JFileChooser.APPROVE_OPTION) {
-        File file = fileChooser.getSelectedFile();
-        String ext = getExtension(file);
-        if ("mid".equals(ext)) {
-          exportToMidi(score, file);
-        } else if ("brl".equals(ext)) {
-          exportToUnicodeBraille(gui.getTranscriber(), file);
-        } else if ("brf".equals(ext)) {
-          exportToBRF(gui.getTranscriber(), file);
-        } else if ("xml".equals(ext)) {
-          exportToMusicXML(score, file);
-        } else if (ext != null) {
-          String message = "Unknown file extension '"+ext+"'";
-          JOptionPane.showMessageDialog(gui, message, "Alert",
-                                        JOptionPane.ERROR_MESSAGE);
-        }
+      File file = selectFile();
+      String ext = getExtension(file);
+      if (file != null) {
+        exportFile(score, file);
+      }
+      else {
+        System.out.println("No file specified.");
       }
     }
   }
 
-  /** Saves the given score to MusicXML format.
+  public File selectFile() {
+    String osName = System.getProperty("os.name");
+    File file = null;
+    if (osName.equals("Mac OS X")) {
+      String title = "Save as...";
+      FileDialog fd = new FileDialog(new Frame(), title, FileDialog.SAVE);
+      fd.setFilenameFilter(new FilenameFilter() {
+        public boolean accept(File dir, String name) {
+          String[] supportedFiles = { "brl", "brf", "midi", "xml"};
+          for (int i = 0; i < supportedFiles.length; i++) {
+            if (name.endsWith(supportedFiles[i])) {
+              return true;
+            }
+          }
+          return false;
+        }
+      });
+      fd.setVisible(true);
+      if (fd.getDirectory() != null && fd.getFile() != null) {
+        String fileName = fd.getDirectory() + "/" + fd.getFile();
+        file = new File(fileName);
+      }
+    }
+    else {
+      JFileChooser fileChooser = new JFileChooser();
+      fileChooser.setAcceptAllFileFilterUsed(false);
+      FileFilter brlFile = new FileTypeFilter(".brl", "Unicode braille (*.brl)");
+      fileChooser.addChoosableFileFilter(brlFile);
+      FileFilter brfFile = new FileTypeFilter(".brf", "Legacy BRF (*.brf)");
+      fileChooser.addChoosableFileFilter(brfFile);
+      FileFilter midiFile = new FileTypeFilter(".mid", "Standard MIDI file (*.mid)");
+      fileChooser.addChoosableFileFilter(midiFile);
+      FileFilter xmlFile = new FileTypeFilter(".xml", "MusicXML file (*.xml)");
+      fileChooser.addChoosableFileFilter(xmlFile);
+      if (fileChooser.showSaveDialog(gui) == JFileChooser.APPROVE_OPTION) {
+        file = fileChooser.getSelectedFile();
+      }
+    }
+    return file;
+  }
+
+  public void exportFile(Score score, File file) {
+    String ext = getExtension(file);
+    if (ext.equals("mid")) {
+      exportToMidi(score, file);
+    }
+    else if (ext.equals("brl")) {
+      exportToUnicodeBraille(gui.getTranscriber(), file);
+    }
+    else if (ext.equals("brf")) {       
+      exportToBRF(gui.getTranscriber(), file);
+    }
+    else if (ext.equals("xml")) {
+      exportToMusicXML(score, file);
+    }
+    else {
+      String message = "Unknown file extension '"+ext+"'\n";
+      message += "Supported file types are .brl, .brf, .mid, and .xml";
+      JOptionPane.showMessageDialog(gui, message, "Alert",
+      JOptionPane.ERROR_MESSAGE);
+    }
+  }
+
+  /** saves the given score to MusicXML format.
    * @param score is the score to save
    * @param file identifies the target filename
    */
@@ -191,6 +207,26 @@ public final class FileSaveAsAction extends javax.swing.AbstractAction {
       }
     } catch (IOException e) {
       e.printStackTrace();
+    }
+  }
+
+  // Extends FileFilter class to support adding multiple filters
+  public class FileTypeFilter extends FileFilter {
+    private String extension;
+    private String description;
+    public FileTypeFilter(String extension, String description) {
+      this.extension = extension;
+      this.description = description;
+    }
+    public boolean accept(File file) {
+      if (file.isDirectory()) {
+        return true;
+      }
+      return file.getName().endsWith(extension);
+    }
+ 
+    public String getDescription() {
+      return description + String.format(" (*%s)", extension);
     }
   }
 

--- a/src/freedots/gui/swing/Main.java
+++ b/src/freedots/gui/swing/Main.java
@@ -22,6 +22,7 @@
  */
 package freedots.gui.swing;
 
+import java.awt.*;
 import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.FontFormatException;
@@ -34,6 +35,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.InputStream;
+import javax.swing.UIManager;
 import javax.sound.midi.MidiUnavailableException;
 import javax.swing.Action;
 import javax.swing.ButtonGroup;
@@ -66,8 +68,9 @@ public final class Main extends JFrame
   implements javax.swing.event.CaretListener,
              freedots.gui.GraphicalUserInterface,
              freedots.playback.PlaybackObserver {
+  private static final String metaKey = (System.getProperty("os.name").equals("Mac OS X") ? "Command" : "CTRL");
   private static final String WELCOME_MESSAGE =
-    "Use \"File -> Open\" (Ctrl+O) to open a new score";
+    String.format("Use \"File -> Open\" (%sKey+O) to open a new score", metaKey);
 
   private Score score;
   public Score getScore() { return score; }
@@ -211,7 +214,6 @@ public final class Main extends JFrame
   public Main(final Transcriber transcriber) {
     super("FreeDots " + freedots.Main.VERSION);
     this.transcriber = transcriber;
-
     try {
       MIDIPlayer player = new MIDIPlayer(metaEventRelay);
       midiPlayer = player;
@@ -533,7 +535,6 @@ public final class Main extends JFrame
     classicalMenu.add(lvBeethovenMenu);
 
     libraryMenu.add(classicalMenu);
-
     JMenu fakebookMenu = new JMenu("Fakebook");
     fakebookMenu.setMnemonic(KeyEvent.VK_F);
 
@@ -591,4 +592,5 @@ public final class Main extends JFrame
     }
     textPane.setCaretPosition(position);
   }
+
 }

--- a/src/freedots/gui/swing/PlayScoreAction.java
+++ b/src/freedots/gui/swing/PlayScoreAction.java
@@ -24,6 +24,7 @@ package freedots.gui.swing;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.Toolkit;
 
 import javax.swing.KeyStroke;
 
@@ -35,7 +36,7 @@ final class PlayScoreAction extends javax.swing.AbstractAction {
     this.gui = gui;
     putValue(SHORT_DESCRIPTION, "Play score or pause playback");
     putValue(ACCELERATOR_KEY,
-             KeyStroke.getKeyStroke(KeyEvent.VK_P, ActionEvent.CTRL_MASK));
+      KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
   }
   /** Starts playback of the currently loaded score.
    * @see java.awt.event.EventListener#actionPerformed

--- a/src/freedots/gui/swing/SingleNoteRenderer.java
+++ b/src/freedots/gui/swing/SingleNoteRenderer.java
@@ -274,8 +274,7 @@ final class SingleNoteRenderer extends JPanel {
   
   protected void drawKey(Graphics g) {
     int keyType = currentNote.getActiveKeySignature().getType();
-    String iconNameBase = null;
-    
+    String iconNameBase = null;    
     if (keyType==0) {
       // at least move the followign note by some pixels right, to make it look sexier.
       globalNotePos+=4;
@@ -287,9 +286,8 @@ final class SingleNoteRenderer extends JPanel {
     }
 
     if (keyType<0) {
-      iconNameBase = "KEY_FLAT_"+keyType;
-    }
-    
+      iconNameBase = "KEY_FLAT_"+(-keyType);
+    }    
     Graphics2D g2 = (Graphics2D)g;
     g2.drawImage(icons.get(iconNameBase), null, 25+4, 0);
     globalNotePos += icons.get(iconNameBase).getWidth() + 8;

--- a/src/freedots/gui/swing/StopPlaybackAction.java
+++ b/src/freedots/gui/swing/StopPlaybackAction.java
@@ -24,7 +24,7 @@ package freedots.gui.swing;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
-
+import java.awt.Toolkit;
 import javax.swing.KeyStroke;
 
 @SuppressWarnings("serial")
@@ -35,7 +35,7 @@ public final class StopPlaybackAction extends javax.swing.AbstractAction {
     this.gui = gui;
     putValue(SHORT_DESCRIPTION, "Stop playback");
     putValue(ACCELERATOR_KEY,
-             KeyStroke.getKeyStroke(KeyEvent.VK_S, ActionEvent.CTRL_MASK));
+      KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
   }
   /** Stops playback.
    * @see java.awt.event.EventListener#actionPerformed


### PR DESCRIPTION
Hi, I made the following changes in this pull request:
1.  Set Swing UI to use awt.FileDialog instead of JFileChooser conditionally for Mac OS X.  This fixes the issue in which Mac users were unable to access files and directories when using the GUI to open and save files.
2. To increase compatibility across OS systems, the accelerator key for the menu shortcut for opening files is changed to set using the Toolkit.getDefaultToolkit().getMenuShortcutKeyMask() method.
3.  Refactored code in FileOpenAction.java and FileSaveAsAction.java 
by extracting functionality from the actionPerformed() methods into specific functions.   The intent is to make the code dryer and increase readability.